### PR TITLE
Fix initial tab example for Angular LTS

### DIFF
--- a/src/examples/tabs/TabsSetSpecificTabActiveExample.tsx
+++ b/src/examples/tabs/TabsSetSpecificTabActiveExample.tsx
@@ -113,7 +113,7 @@ export const TabsSetSpecificTabActiveExample = () => {
           tags="angular"
           allowCopy={true}
           code={`
-            <goa-tabs initialTab={1}>
+            <goa-tabs initialtab="1">
               <goa-tab>
                 <div slot="heading">All</div>
                 <goa-table width="100%">


### PR DESCRIPTION
## Summary
- correct the Angular 3.2.2 example for setting the initial tab

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_685f03a2c458832c878695480571ba47